### PR TITLE
Feature #112: migrate readIsolationLevel to Enum

### DIFF
--- a/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/kafka/KConsumer.kt
+++ b/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/kafka/KConsumer.kt
@@ -61,7 +61,7 @@ class KConsumer(
             config[ConsumerConfig.GROUP_ID_CONFIG] = tableTopicConfig.kafkaConfig.groupID
         }
 
-        if (tableTopicConfig.kafkaConfig.readIsolationLevel != KConfig.IsolationLevel.DEFAULT && tableTopicConfig.kafkaConfig.isolationLevel.isBlank()) {
+        if (tableTopicConfig.kafkaConfig.isolationLevel.isBlank()) {
             config[ConsumerConfig.ISOLATION_LEVEL_CONFIG] = tableTopicConfig.kafkaConfig.readIsolationLevel.isolationLevel
         } else {
             config[ConsumerConfig.ISOLATION_LEVEL_CONFIG] = tableTopicConfig.kafkaConfig.isolationLevel

--- a/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/kafka/KConsumer.kt
+++ b/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/kafka/KConsumer.kt
@@ -1,5 +1,6 @@
 package de.p7s1.qa.sevenfacette.kafka
 
+import de.p7s1.qa.sevenfacette.kafka.config.KConfig
 import de.p7s1.qa.sevenfacette.kafka.config.KTableTopicConfig
 import de.p7s1.qa.sevenfacette.kafka.config.SaslConfiguration
 import kotlinx.coroutines.CoroutineScope
@@ -60,7 +61,9 @@ class KConsumer(
             config[ConsumerConfig.GROUP_ID_CONFIG] = tableTopicConfig.kafkaConfig.groupID
         }
 
-        if (!tableTopicConfig.kafkaConfig.isolationLevel.isBlank()) {
+        if (tableTopicConfig.kafkaConfig.readIsolationLevel != KConfig.IsolationLevel.DEFAULT && tableTopicConfig.kafkaConfig.isolationLevel.isBlank()) {
+            config[ConsumerConfig.ISOLATION_LEVEL_CONFIG] = tableTopicConfig.kafkaConfig.readIsolationLevel.isolationLevel
+        } else {
             config[ConsumerConfig.ISOLATION_LEVEL_CONFIG] = tableTopicConfig.kafkaConfig.isolationLevel
         }
 

--- a/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/kafka/config/KConfig.kt
+++ b/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/kafka/config/KConfig.kt
@@ -1,5 +1,7 @@
 package de.p7s1.qa.sevenfacette.kafka.config
 
+import de.p7s1.qa.sevenfacette.kafka.config.KConfig.IsolationLevel.READ_UNCOMMITTED as READ_UNCOMMITTED1
+
 /**
  * Holds the basic Kafka configuration parameter
  *
@@ -25,7 +27,7 @@ class KConfig {
 
     var groupID: String = ""
 
-    var readIsolationLevel: IsolationLevel = IsolationLevel.DEFAULT
+    var readIsolationLevel: IsolationLevel = IsolationLevel.READ_UNCOMMITTED
 
     @Deprecated("Please use the new Enum instead", ReplaceWith("readIsolationLevel"))
     var isolationLevel: String = ""
@@ -35,7 +37,7 @@ class KConfig {
     var autoCommitInterval: Int = 0
 
     enum class IsolationLevel(val isolationLevel: String) {
-        DEFAULT(""),
-        READ_COMMITTED("read_committed")
+        READ_COMMITTED("read_committed"),
+        READ_UNCOMMITTED("read_uncommitted")
     }
 }

--- a/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/kafka/config/KConfig.kt
+++ b/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/kafka/config/KConfig.kt
@@ -25,9 +25,17 @@ class KConfig {
 
     var groupID: String = ""
 
+    var readIsolationLevel: IsolationLevel = IsolationLevel.DEFAULT
+
+    @Deprecated("Please use the new Enum instead", ReplaceWith("readIsolationLevel"))
     var isolationLevel: String = ""
 
     var autoCommit: Boolean = false
 
     var autoCommitInterval: Int = 0
+
+    enum class IsolationLevel(val isolationLevel: String) {
+        DEFAULT(""),
+        READ_COMMITTED("read_committed")
+    }
 }


### PR DESCRIPTION
See https://github.com/p7s1-ctf/SevenFacette/issues/112
To improve usability, the KConfig::isolationLevel has been deprecated in favor of KConfig::readIsolationLevel. The new field uses an Enum, making it more comfortable to choose between supported values.